### PR TITLE
Feat: setup k8s service and ingress to match deployments, can curl the endpoints

### DIFF
--- a/app/Taskfile.yaml
+++ b/app/Taskfile.yaml
@@ -6,6 +6,6 @@ tasks:
     cmds:
       - docker build -t gene-saver-app .
   run-app:
-    desc: runs vue application on port 8081
+    desc: runs vue application on port 8080
     cmds:
-      - docker run -it -p 8081:81 gene-saver-app
+      - docker run -it -p 8080:80 gene-saver-app

--- a/app/conf.d/default.conf
+++ b/app/conf.d/default.conf
@@ -1,0 +1,43 @@
+server {
+    listen       80;
+    server_name  0.0.0.0;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/app/deployment.yaml
+++ b/app/deployment.yaml
@@ -14,15 +14,15 @@ spec:
     spec:
       containers:
       - name: gene-saver-app
-        image: miriamgrigsby/gene-saver-app:1.0.0
+        image: miriamgrigsby/gene-saver-app:1.0.3
         imagePullPolicy: IfNotPresent
         ports:
-          - containerPort: 8081  # Should match the port number that the Go application listens on
+          - containerPort: 80  # Should match the port number that the Vue application listens on
         # TODO wire these up in vue app
         # livenessProbe:           # To check the health of the Pod
         #   httpGet:
         #     path: /health
-        #     port: 8081
+        #     port: 80
         #     scheme: HTTP
         #   initialDelaySeconds: 5
         #   periodSeconds: 15
@@ -30,7 +30,7 @@ spec:
         # readinessProbe:          # To check if the Pod is ready to serve traffic or not
         #   httpGet:
         #     path: /readiness
-        #     port: 8081
+        #     port: 80
         #     scheme: HTTP
         #   initialDelaySeconds: 5
         #   timeoutSeconds: 1

--- a/app/ingress.yaml
+++ b/app/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gene-saver-app
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: gene-saver-app
+            port:
+              number: 8080

--- a/app/service.yaml
+++ b/app/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: gene-saver-app
+spec:
+  selector:
+      app: gene-saver-app
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
   golangapp:
     build: ./platform
     ports:
-      - 9992:81
+      - 4040:4040
     depends_on:
       - postgres
   client:

--- a/platform/Taskfile.yaml
+++ b/platform/Taskfile.yaml
@@ -5,7 +5,7 @@ tasks:
     dir: '{{.USER_WORKING_DIR}}'
     desc: Executes main.go file
     cmds:
-      - cd resolver && go run .
+      - go run .
   build-image:
     desc: builds docker image
     cmds:

--- a/platform/ingress.yaml
+++ b/platform/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gene-saver-platform
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+        - path: /testpath
+          pathType: Prefix
+          backend:
+            service:
+              name: gene-saver-platform
+              port:
+                number: 4040

--- a/platform/service.yaml
+++ b/platform/service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: gene-saver-platform
+spec:
+  selector:
+      app: gene-saver-platform
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 4040


### PR DESCRIPTION
- setup k8s service and ingress for vue and golang apps
- setup ingress controller in the cluster with helm
- confirmed endpoints were successfully created and can be curled
- used a jump host to connect my RDS instance to Datagrip for faster postgres dev
- fixed a docker compose issue in my ec2 instance that was blocking me from running the app successfully